### PR TITLE
Fix Unused Imports and Any Types in FixedNovelWriter.tsx

### DIFF
--- a/src/components/novel/FixedNovelWriter.tsx
+++ b/src/components/novel/FixedNovelWriter.tsx
@@ -3,10 +3,7 @@
 // This is a fixed version of the NovelWriter component that properly handles the OpenRouter API response
 // The main changes are in the autoPilotWrite function to ensure it correctly processes the response
 
-import React, { useState, useEffect, useCallback } from 'react';
-import { motion, AnimatePresence } from 'framer-motion';
-import { BookOpen, Pen, Sparkles, Download, Share2, Save, Wand2, Brain, Zap, Trash2, Upload, History, CheckCircle, AlertCircle, Loader2 } from 'lucide-react';
-import { Button } from '@/components/ui/button';
+import React, { useState } from 'react';
 import { apiService } from '@/services/api';
 
 // Import the original NovelWriter component and extend it
@@ -17,11 +14,29 @@ const useFixedAutoPilot = () => {
   const [debugInfo, setDebugInfo] = useState<string>('');
   const [lastResponse, setLastResponse] = useState<Record<string, unknown> | null>(null);
 
+  // Define proper types for the parameters
+  interface Project {
+    currentChapterIndex: number;
+    chapters: Array<{
+      title: string;
+      content: string;
+      summary?: string;
+    }>;
+    [key: string]: unknown;
+  }
+
+  interface Chapter {
+    title: string;
+    content: string;
+    summary?: string;
+    [key: string]: unknown;
+  }
+
   // This is the fixed version of the autoPilotWrite function
   const fixedAutoPilotWrite = async (
     isGenerating: boolean,
-    currentProject: any,
-    currentChapter: any,
+    currentProject: Project,
+    currentChapter: Chapter,
     chapterWordCount: number,
     editorContent: string,
     selectedLanguage: string,


### PR DESCRIPTION
## Description
This PR fixes ESLint errors in FixedNovelWriter.tsx related to unused imports and any types that were preventing the build from completing.

## Changes Made
1. Removed unused imports:
   - Removed unused React hooks: `useEffect`, `useCallback`
   - Removed unused framer-motion imports: `motion`, `AnimatePresence`
   - Removed unused Lucide icons: `BookOpen`, `Pen`, `Sparkles`, etc.
   - Removed unused UI components: `Button`

2. Fixed `any` types:
   - Created proper interfaces for `Project` and `Chapter` types
   - Replaced `any` with these typed interfaces in function parameters

## How to Test
1. Run `npm run build` to verify that the ESLint errors are resolved
2. Test the Auto-Pilot feature to ensure it still works correctly

## Additional Notes
These changes are purely to fix ESLint errors and do not affect the functionality of the Auto-Pilot feature.

@intcydv can click here to [continue refining the PR](https://app.all-hands.dev/conversations/6772edd8537f4b609dc021df2956b62f)