### PR TITLE
Fix ChatResponse Type in FixedNovelWriter.tsx

### DIFF
--- a/src/components/novel/FixedNovelWriter.tsx
+++ b/src/components/novel/FixedNovelWriter.tsx
@@ -9,10 +9,46 @@ import { apiService } from '@/services/api';
 // Import the original NovelWriter component and extend it
 import OriginalNovelWriter from './NovelWriter';
 
+// Import the EnhancedChatResponse interface
+import { enhancedApiService } from '@/services/enhancedApi';
+
 // Create a fixed version of the autoPilotWrite function
 const useFixedAutoPilot = () => {
   const [debugInfo, setDebugInfo] = useState<string>('');
-  const [lastResponse, setLastResponse] = useState<Record<string, unknown> | null>(null);
+  
+  // Define the ChatResponse type based on the API response structure
+  type ChatResponse = {
+    response?: string;
+    message?: string;
+    content?: string;
+    data?: string;
+    conversation_id?: string;
+    model?: string;
+    timestamp?: string;
+    status?: string;
+    choices?: Array<{
+      message?: {
+        content?: string;
+        role?: string;
+      };
+      text?: string;
+      index?: number;
+    }>;
+    usage?: {
+      prompt_tokens: number;
+      completion_tokens: number;
+      total_tokens: number;
+    };
+    error?: {
+      message: string;
+      type?: string;
+      code?: string | number;
+    };
+    debug_info?: string;
+    [key: string]: unknown; // Index signature to allow any string key
+  };
+  
+  const [lastResponse, setLastResponse] = useState<ChatResponse | null>(null);
 
   // Define proper types for the parameters
   interface Project {


### PR DESCRIPTION
## Description
This PR fixes the TypeScript error in FixedNovelWriter.tsx related to the ChatResponse type that was preventing the build from completing.

## Changes Made
1. Added a proper ChatResponse type definition:
   - Defined a comprehensive ChatResponse type with all possible fields
   - Added an index signature `[key: string]: unknown` to allow any string key
   - This fixes the error: "Type 'ChatResponse' is not assignable to type 'Record<string, unknown>'"

2. Imported the enhancedApiService to ensure consistency with the API service

## How to Test
1. Run `npm run build` to verify that the TypeScript error is resolved
2. Test the Auto-Pilot feature to ensure it still works correctly

## Additional Notes
This change is purely to fix a TypeScript error and does not affect the functionality of the Auto-Pilot feature.

@intcydv can click here to [continue refining the PR](https://app.all-hands.dev/conversations/6772edd8537f4b609dc021df2956b62f)